### PR TITLE
Feature: MemoizeTrait

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,3 +247,50 @@ use StellarWP\Memoize\Drivers\MemoryDriver;
 
 $memoizer = new Memoizer(new MemoryDriver());
 ```
+
+## Traits
+
+The `MemoizeTrait` provides a convenient way to add memoization to your classes, ensuring that cached results are isolated to each instance,
+preventing cross-talk or key collisions between different objects. Ideal for enhancing existing classes with lightweight, instance-specific caching.
+
+> 💡 The MemoizeTrait uses in-memory storage only and cannot be changed.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace StellarWP\MyProject;
+
+use StellarWP\Memoize\MemoizerInterface;
+use StellarWP\Memoize\Traits\MemoizeTrait;
+
+/**
+ * An example class inside your project.
+ */
+class MyProjectClass implements MemoizerInterface
+{
+    use MemoizeTrait;
+
+    public function find( string $id ): string {
+       $result = $this->get( $id );
+
+        if ( ! $result ) {
+            $result = 'some very expensive operation';
+
+            $this->set( $id, $result );
+        }
+
+        return $result;
+    }
+
+    public function delete( string $id ): bool
+    {
+        $this->forget( $id );
+
+        // Run delete operation...
+
+        return true;
+    }
+}
+```

--- a/src/Memoize/Drivers/MemoryDriver.php
+++ b/src/Memoize/Drivers/MemoryDriver.php
@@ -4,58 +4,10 @@ declare(strict_types=1);
 
 namespace StellarWP\Memoize\Drivers;
 
-use Closure;
-use StellarWP\Arrays\Arr;
 use StellarWP\Memoize\Contracts\DriverInterface;
+use StellarWP\Memoize\Traits\MemoizeTrait;
 
 final class MemoryDriver implements DriverInterface
 {
-    /**
-     * @var array
-     */
-    private array $cache = [];
-
-    /**
-     * @inheritDoc
-     */
-    public function get(?string $key = null)
-    {
-        if (!$key) {
-            return $this->cache;
-        }
-
-        return Arr::get($this->cache, $key);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function set(string $key, $value): void
-    {
-        if ($value instanceof Closure) {
-            $value = $value();
-        }
-
-        $this->cache = Arr::set($this->cache, explode('.', $key), $value);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function has(string $key): bool
-    {
-        return Arr::has($this->cache, $key);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function forget(?string $key = null): void
-    {
-        if ($key) {
-            Arr::forget($this->cache, $key);
-        } else {
-            $this->cache = [];
-        }
-    }
+    use MemoizeTrait;
 }

--- a/src/Memoize/Traits/MemoizeTrait.php
+++ b/src/Memoize/Traits/MemoizeTrait.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StellarWP\Memoize\Traits;
+
+use Closure;
+use StellarWP\Arrays\Arr;
+use StellarWP\Memoize\Contracts\MemoizerInterface;
+
+/**
+ * A memory based memoizer trait.
+ *
+ * @mixin MemoizerInterface
+ */
+trait MemoizeTrait
+{
+    /**
+     * @var array<string, mixed>
+     */
+    protected static array $cached = [];
+
+    /**
+     * Get a value from the cache.
+     *
+     * @param ?string $key The cache key using dot notation. If null, the entire cache will be returned.
+     *
+     * @return mixed
+     */
+    public function get(?string $key = null)
+    {
+        if (!$key) {
+            return static::$cached;
+        }
+
+        return Arr::get(static::$cached, $key);
+    }
+
+    /**
+     * Set a value in the cache.
+     *
+     * @param string $key The cache key using dot notation.
+     * @param mixed $value The value to store in the cache.
+     *
+     * @return void
+     */
+    public function set(string $key, $value): void
+    {
+        if ($value instanceof Closure) {
+            $value = $value();
+        }
+
+        static::$cached = Arr::set(static::$cached, explode('.', $key), $value);
+    }
+
+    /**
+     * Check if a key exists in the cache.
+     *
+     * @param string $key The cache key using dot notation.
+     *
+     * @return boolean
+     */
+    public function has(string $key): bool
+    {
+        return Arr::has(static::$cached, $key);
+    }
+
+    /**
+     * Remove a key from the cache.
+     *
+     * @param ?string $key The cache key using dot notation. If null, the entire cache will be cleared.
+     *
+     * @return void
+     */
+    public function forget(?string $key = null): void
+    {
+        if ($key) {
+            Arr::forget(static::$cached, $key);
+        } else {
+            static::$cached = [];
+        }
+    }
+}

--- a/src/Memoize/Traits/MemoizeTrait.php
+++ b/src/Memoize/Traits/MemoizeTrait.php
@@ -6,12 +6,14 @@ namespace StellarWP\Memoize\Traits;
 
 use Closure;
 use StellarWP\Arrays\Arr;
+use StellarWP\Memoize\Contracts\DriverInterface;
 use StellarWP\Memoize\Contracts\MemoizerInterface;
 
 /**
  * A memory based memoizer trait.
  *
  * @mixin MemoizerInterface
+ * @mixin DriverInterface
  */
 trait MemoizeTrait
 {

--- a/tests/unit/MemoizeTest.php
+++ b/tests/unit/MemoizeTest.php
@@ -19,13 +19,13 @@ final class MemoizeTest extends MemoizeTestCase
      */
     public function driverProvider(): array
     {
-        $memoizerTrait = new class implements MemoizerInterface {
+        $memoizeTrait = new class implements MemoizerInterface {
             use MemoizeTrait;
         };
 
         return [
             'MemoryDriver' => [new Memoizer(new MemoryDriver())],
-            'MemoizeTrait' => [$memoizerTrait],
+            'MemoizeTrait' => [$memoizeTrait],
         ];
     }
 

--- a/tests/unit/MemoizeTest.php
+++ b/tests/unit/MemoizeTest.php
@@ -8,65 +8,92 @@ use StellarWP\Memoize\Contracts\MemoizerInterface;
 use StellarWP\Memoize\Drivers\MemoryDriver;
 use StellarWP\Memoize\Memoizer;
 use StellarWP\Memoize\Tests\Helper\MemoizeTestCase;
+use StellarWP\Memoize\Traits\MemoizeTrait;
 
 final class MemoizeTest extends MemoizeTestCase
 {
-    private MemoizerInterface $memoizer;
-
-    public function _setUp(): void
+    /**
+     * Data provider for memoize drivers.
+     *
+     * @return array<string, array{0: MemoizerInterface}>
+     */
+    public function driverProvider(): array
     {
-        $this->memoizer = new Memoizer(new MemoryDriver());
+        $memoizerTrait = new class implements MemoizerInterface {
+            use MemoizeTrait;
+        };
+
+        return [
+            'MemoryDriver' => [new Memoizer(new MemoryDriver())],
+            'MemoizeTrait' => [$memoizerTrait],
+        ];
     }
 
-    public function testSetsSimpleValue(): void
+    /**
+     * @dataProvider driverProvider
+     */
+    public function testSetsSimpleValue(MemoizerInterface $memoizer): void
     {
-        $this->memoizer->set('foo', 'bar');
-        $this->assertEquals('bar', $this->memoizer->get('foo'));
+        $memoizer->set('foo', 'bar');
+        $this->assertEquals('bar', $memoizer->get('foo'));
     }
 
-    public function testSetsDeepValue(): void
+    /**
+     * @dataProvider driverProvider
+     */
+    public function testSetsDeepValue(MemoizerInterface $memoizer): void
     {
-        $this->memoizer->set('foo.bar.bork.blarg.moo', 'baz');
-        $this->assertEquals('baz', $this->memoizer->get('foo.bar.bork.blarg.moo'));
+        $memoizer->set('foo.bar.bork.blarg.moo', 'baz');
+        $this->assertEquals('baz', $memoizer->get('foo.bar.bork.blarg.moo'));
     }
 
-    public function testForgetsEverything(): void
+    /**
+     * @dataProvider driverProvider
+     */
+    public function testForgetsEverything(MemoizerInterface $memoizer): void
     {
-        $this->memoizer->set('foo.bar.bork.blarg.moo', 'baz');
-        $this->memoizer->forget();
-        $this->assertFalse($this->memoizer->has('foo.bar.bork.blarg.moo'));
-        $this->assertFalse($this->memoizer->has('foo.bar.bork.blarg'));
-        $this->assertFalse($this->memoizer->has('foo.bar.bork'));
-        $this->assertFalse($this->memoizer->has('foo.bar'));
-        $this->assertFalse($this->memoizer->has('foo'));
+        $memoizer->set('foo.bar.bork.blarg.moo', 'baz');
+        $memoizer->forget();
+        $this->assertFalse($memoizer->has('foo.bar.bork.blarg.moo'));
+        $this->assertFalse($memoizer->has('foo.bar.bork.blarg'));
+        $this->assertFalse($memoizer->has('foo.bar.bork'));
+        $this->assertFalse($memoizer->has('foo.bar'));
+        $this->assertFalse($memoizer->has('foo'));
     }
 
-    public function testForgetsLeaves(): void
+    /**
+     * @dataProvider driverProvider
+     */
+    public function testForgetsLeaves(MemoizerInterface $memoizer): void
     {
-        $this->memoizer->set('foo.bar.bork.blarg.moo', 'baz');
-        $this->memoizer->set('foo.bar.bork.blarg.oink', 'lol');
-        $this->memoizer->forget('foo.bar.bork.blarg.moo');
-        $this->assertFalse($this->memoizer->has('foo.bar.bork.blarg.moo'));
-        $this->assertTrue($this->memoizer->has('foo.bar.bork.blarg.oink'));
+        $memoizer->set('foo.bar.bork.blarg.moo', 'baz');
+        $memoizer->set('foo.bar.bork.blarg.oink', 'lol');
+        $memoizer->forget('foo.bar.bork.blarg.moo');
+        $this->assertFalse($memoizer->has('foo.bar.bork.blarg.moo'));
+        $this->assertTrue($memoizer->has('foo.bar.bork.blarg.oink'));
     }
 
-    public function testForgetsBranches(): void
+    /**
+     * @dataProvider driverProvider
+     */
+    public function testForgetsBranches(MemoizerInterface $memoizer): void
     {
-        $this->memoizer->set('foo.bar.bork.blarg.moo', 'baz');
-        $this->memoizer->set('foo.bar.bork.blarg.oink', 'lol');
-        $this->memoizer->forget('foo.bar.bork');
-        $this->assertFalse($this->memoizer->has('foo.bar.bork'));
-        $this->assertTrue($this->memoizer->has('foo.bar'));
+        $memoizer->set('foo.bar.bork.blarg.moo', 'baz');
+        $memoizer->set('foo.bar.bork.blarg.oink', 'lol');
+        $memoizer->forget('foo.bar.bork');
+        $this->assertFalse($memoizer->has('foo.bar.bork'));
+        $this->assertTrue($memoizer->has('foo.bar'));
     }
 
-    public function testForgetsSimpleValues(): void
+    /**
+     * @dataProvider driverProvider
+     */
+    public function testForgetsSimpleValues(MemoizerInterface $memoizer): void
     {
-        $this->memoizer->set('foo', 'baz');
-        $this->memoizer->set('bork', 'lol');
-        $this->memoizer->forget('foo');
-        $this->assertFalse($this->memoizer->has('foo'));
-        $this->assertTrue($this->memoizer->has('bork'));
+        $memoizer->set('foo', 'baz');
+        $memoizer->set('bork', 'lol');
+        $memoizer->forget('foo');
+        $this->assertFalse($memoizer->has('foo'));
+        $this->assertTrue($memoizer->has('bork'));
     }
-
 }
-


### PR DESCRIPTION
### Main Changes

This adds a `MemoizeTrait` for use in existing classes where you want a convenient way to add Memoization while ensuring no cross-talk/key collisions between objects. 