### PR TITLE
Bugfix: Only null keys should fetch all items, and disallow empty strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A flexible memoization library for memory caching.
   - [Using with a dependency injection container](#using-with-a-dependency-injection-container)
 - [Drivers](#drivers)
   - [MemoryDriver](#memorydriver)
+- [Traits](#traits)
 
 ## Memoization
 

--- a/src/Memoize/Contracts/DriverInterface.php
+++ b/src/Memoize/Contracts/DriverInterface.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace StellarWP\Memoize\Contracts;
 
+use InvalidArgumentException;
+
 interface DriverInterface
 {
     /**
      * Get a value from the cache.
      *
      * @param ?string $key The cache key using dot notation. If null, the entire cache will be returned.
+     *
+     * @throws InvalidArgumentException If the key is an empty string.
+     *
      * @return mixed
      */
     public function get(?string $key = null);
@@ -19,6 +24,9 @@ interface DriverInterface
      *
      * @param string $key The cache key using dot notation.
      * @param mixed $value The value to store in the cache.
+     *
+     * @throws InvalidArgumentException If the key is an empty string.
+     *
      * @return void
      */
     public function set(string $key, $value): void;
@@ -27,6 +35,9 @@ interface DriverInterface
      * Check if a key exists in the cache.
      *
      * @param string $key The cache key using dot notation.
+     *
+     * @throws InvalidArgumentException If the key is an empty string.
+     *
      * @return boolean
      */
     public function has(string $key): bool;
@@ -35,6 +46,9 @@ interface DriverInterface
      * Remove a key from the cache.
      *
      * @param ?string $key The cache key using dot notation. If null, the entire cache will be cleared.
+     *
+     * @throws InvalidArgumentException If the key is an empty string.
+     *
      * @return void
      */
     public function forget(?string $key = null): void;

--- a/src/Memoize/Contracts/MemoizerInterface.php
+++ b/src/Memoize/Contracts/MemoizerInterface.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace StellarWP\Memoize\Contracts;
 
+use InvalidArgumentException;
+
 interface MemoizerInterface
 {
     /**
      * Get a value from the memoization cache.
      *
      * @param ?string $key The cache key using dot notation. If null, the entire cache will be returned.
+     *
+     * @throws InvalidArgumentException If the key is an empty string.
+     *
      * @return mixed
      */
     public function get(?string $key = null);
@@ -19,6 +24,9 @@ interface MemoizerInterface
      *
      * @param string $key The cache key using dot notation.
      * @param mixed $value The value to store in the cache.
+     *
+     * @throws InvalidArgumentException If the key is an empty string.
+     *
      * @return void
      */
     public function set(string $key, $value): void;
@@ -27,6 +35,9 @@ interface MemoizerInterface
      * Check if a key exists in the memoization cache.
      *
      * @param string $key The cache key using dot notation.
+     *
+     * @throws InvalidArgumentException If the key is an empty string.
+     *
      * @return bool
      */
     public function has(string $key): bool;
@@ -35,6 +46,9 @@ interface MemoizerInterface
      * Remove a key from the memoization cache.
      *
      * @param ?string $key The cache key using dot notation. If null, the entire cache will be cleared.
+     *
+     * @throws InvalidArgumentException If the key is an empty string.
+     *
      * @return void
      */
     public function forget(?string $key = null): void;

--- a/src/Memoize/Memoizer.php
+++ b/src/Memoize/Memoizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace StellarWP\Memoize;
 
+use InvalidArgumentException;
 use StellarWP\Memoize\Contracts\DriverInterface;
 use StellarWP\Memoize\Contracts\MemoizerInterface;
 use StellarWP\Memoize\Drivers\MemoryDriver;
@@ -37,6 +38,9 @@ final class Memoizer implements MemoizerInterface
      * Get a value from the memoization cache.
      *
      * @param ?string $key The cache key using dot notation. If null, the entire cache will be returned.
+     *
+     * @throws InvalidArgumentException If the key is an empty string.
+     *
      * @return mixed
      */
     public function get(?string $key = null)
@@ -49,6 +53,9 @@ final class Memoizer implements MemoizerInterface
      *
      * @param string $key The cache key using dot notation.
      * @param mixed $value The value to store in the cache.
+     *
+     * @throws InvalidArgumentException If the key is an empty string.
+     *
      * @return void
      */
     public function set(string $key, $value): void
@@ -60,6 +67,9 @@ final class Memoizer implements MemoizerInterface
      * Check if a key exists in the memoization cache.
      *
      * @param string $key The cache key using dot notation.
+     *
+     * @throws InvalidArgumentException If the key is an empty string.
+     *
      * @return boolean
      */
     public function has(string $key): bool
@@ -71,6 +81,9 @@ final class Memoizer implements MemoizerInterface
      * Remove a key from the memoization cache.
      *
      * @param ?string $key The cache key using dot notation. If null, the entire cache will be cleared.
+     *
+     * @throws InvalidArgumentException If the key is an empty string.
+     *
      * @return void
      */
     public function forget(?string $key = null): void

--- a/src/Memoize/Traits/MemoizeTrait.php
+++ b/src/Memoize/Traits/MemoizeTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace StellarWP\Memoize\Traits;
 
 use Closure;
+use InvalidArgumentException;
 use StellarWP\Arrays\Arr;
 use StellarWP\Memoize\Contracts\DriverInterface;
 use StellarWP\Memoize\Contracts\MemoizerInterface;
@@ -27,12 +28,18 @@ trait MemoizeTrait
      *
      * @param ?string $key The cache key using dot notation. If null, the entire cache will be returned.
      *
+     * @throws InvalidArgumentException If the key is an empty string.
+     *
      * @return mixed
      */
     public function get(?string $key = null)
     {
-        if (!$key) {
+        if ($key === null) {
             return static::$cached;
+        }
+
+        if ($key === '') {
+            throw new InvalidArgumentException('Memoize key cannot be an empty string');
         }
 
         return Arr::get(static::$cached, $key);
@@ -44,10 +51,16 @@ trait MemoizeTrait
      * @param string $key The cache key using dot notation.
      * @param mixed $value The value to store in the cache.
      *
+     * @throws InvalidArgumentException If the key is an empty string.
+     *
      * @return void
      */
     public function set(string $key, $value): void
     {
+        if ($key === '') {
+            throw new InvalidArgumentException('Memoize key cannot be an empty string');
+        }
+
         if ($value instanceof Closure) {
             $value = $value();
         }
@@ -60,10 +73,16 @@ trait MemoizeTrait
      *
      * @param string $key The cache key using dot notation.
      *
+     * @throws InvalidArgumentException If the key is an empty string.
+     *
      * @return boolean
      */
     public function has(string $key): bool
     {
+        if ($key === '') {
+            throw new InvalidArgumentException('Memoize key cannot be an empty string');
+        }
+
         return Arr::has(static::$cached, $key);
     }
 
@@ -72,11 +91,17 @@ trait MemoizeTrait
      *
      * @param ?string $key The cache key using dot notation. If null, the entire cache will be cleared.
      *
+     * @throws InvalidArgumentException If the key is an empty string.
+     *
      * @return void
      */
     public function forget(?string $key = null): void
     {
-        if ($key) {
+        if ($key === '') {
+            throw new InvalidArgumentException('Memoize key cannot be an empty string');
+        }
+
+        if ($key !== null) {
             Arr::forget(static::$cached, $key);
         } else {
             static::$cached = [];

--- a/tests/unit/MemoizeTest.php
+++ b/tests/unit/MemoizeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace StellarWP\Memoize\Tests\Unit;
 
+use InvalidArgumentException;
 use StellarWP\Memoize\Contracts\MemoizerInterface;
 use StellarWP\Memoize\Drivers\MemoryDriver;
 use StellarWP\Memoize\Memoizer;
@@ -96,4 +97,63 @@ final class MemoizeTest extends MemoizeTestCase
         $this->assertFalse($memoizer->has('foo'));
         $this->assertTrue($memoizer->has('bork'));
     }
+
+    /**
+     * @dataProvider driverProvider
+     */
+    public function testItAllowsEmptyNonNullValues(MemoizerInterface $memoizer): void
+    {
+        $memoizer->set('0', 'baz');
+        $memoizer->set('false', 'lol');
+        $this->assertTrue($memoizer->has('0'));
+        $this->assertTrue($memoizer->has('false'));
+        $this->assertSame('baz', $memoizer->get('0'));
+        $this->assertSame('lol', $memoizer->get('false'));
+
+        $memoizer->forget('0');
+        $memoizer->forget('false');
+        $this->assertFalse($memoizer->has('0'));
+        $this->assertFalse($memoizer->has('false'));
+    }
+
+    /**
+     * @dataProvider driverProvider
+     */
+    public function testItThrowsExceptionSettingEmptyString(MemoizerInterface $memoizer): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Memoize key cannot be an empty string');
+        $memoizer->set('', 'baz');
+    }
+
+    /**
+     * @dataProvider driverProvider
+     */
+    public function testItThrowsExceptionGettingEmptyString(MemoizerInterface $memoizer): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Memoize key cannot be an empty string');
+        $memoizer->get('');
+    }
+
+    /**
+     * @dataProvider driverProvider
+     */
+    public function testItThrowsExceptionHasEmptyString(MemoizerInterface $memoizer): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Memoize key cannot be an empty string');
+        $memoizer->has('');
+    }
+
+    /**
+     * @dataProvider driverProvider
+     */
+    public function testItThrowsExceptionForgettingEmptyString(MemoizerInterface $memoizer): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Memoize key cannot be an empty string');
+        $memoizer->forget('');
+    }
+
 }


### PR DESCRIPTION
### Main Changes

This updates the library so we can properly store string keys like `'0'`, `'false'` etc...and properly fail if an empty string, e.g. `''` is passed as that would likely be a situation where a developer did not expect that to happen and it should let them know immediately.